### PR TITLE
Added register displays

### DIFF
--- a/app/src/main/java/io/github/danielt3131/mipsemu/FileUtils.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/FileUtils.java
@@ -1,0 +1,17 @@
+package io.github.danielt3131.mipsemu;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+import android.util.Log;
+
+public class FileUtils {
+
+    public static String getFileName(Context context, Uri fileUri){
+        Cursor cursor = context.getContentResolver().query(fileUri, null, null, null, null);
+        int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+        cursor.moveToFirst();
+        return cursor.getString(nameIndex);
+    }
+}

--- a/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
@@ -84,4 +84,20 @@ public class MachineInterface {
     public void updateCacheHitDisplay(String cacheHitRate) {
         cacheHitRateDisplay.setText("Cache Hits: " + cacheHitRate);
     }
+
+    /**
+     * Method to clear all the displays when the machine is reset
+     */
+    public void clearAll() {
+        String blank = "";
+        String[] blankRegisters = new String[registers.length];
+        for (int i = 0; i < blankRegisters.length; i++) {
+            blankRegisters[i] = blank;
+        }
+        updateAllRegisters(blankRegisters);
+        updateProgramCounter(blank);
+        updateCacheHitDisplay(blank);
+        updateMemoryDisplay(blank);
+        updateInstructionDisplay(blank);
+    }
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
@@ -2,6 +2,7 @@ package io.github.danielt3131.mipsemu;
 
 import android.app.Activity;
 import android.content.Context;
+import android.util.Log;
 import android.widget.TextView;
 
 /**
@@ -49,7 +50,28 @@ public class MachineInterface {
         instructionDisplay.setText("Instructions: " + instructions);
     }
 
+    /**
+     * Updates an individual register display
+     * @param register The register to update
+     * @param registerValue The register value
+     */
     public void updateIndividualRegister(int register, String registerValue) {
         registers[register].setText(registerValue);
+        Log.d("Updated Register: " + register, registerValue);
+    }
+
+    /**
+     * Updates all the register displays
+     * @param registerValues The string array containing the value of every register
+     */
+    public void updateAllRegisters(String[] registerValues) {
+        for (int i = 0; i < registers.length; i++) {
+            try {
+                registers[i].setText(registerValues[i]);
+                Log.d("Updated Register: " + i, registerValues[i]);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                Log.e("Update Register", e.getMessage());
+            }
+        }
     }
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
@@ -56,8 +56,8 @@ public class MachineInterface {
      * @param registerValue The register value
      */
     public void updateIndividualRegister(int register, String registerValue) {
-        registers[register].setText(registerValue);
-        Log.d("Updated Register: " + register, registerValue);
+        registers[register].setText(Reference.registerNames[register] + ": " + registerValue);
+        Log.d("Updated Register: " + Reference.registerNames[register], registerValue);
     }
 
     /**
@@ -67,8 +67,8 @@ public class MachineInterface {
     public void updateAllRegisters(String[] registerValues) {
         for (int i = 0; i < registers.length; i++) {
             try {
-                registers[i].setText(registerValues[i]);
-                Log.d("Updated Register: " + i, registerValues[i]);
+                registers[i].setText(Reference.registerNames[i] + ": " + registerValues[i]);
+                Log.d("Updated Register: " + Reference.registerNames[i], registerValues[i]);
             } catch (ArrayIndexOutOfBoundsException e) {
                 Log.e("Update Register", e.getMessage());
             }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
@@ -9,12 +9,20 @@ import android.widget.TextView;
  */
 public class MachineInterface {
     private TextView memoryDisplay, programCounterDisplay, instructionDisplay;
+    private TextView[] registers;
 
-
-    public MachineInterface(TextView memoryDisplay, TextView programCounterDisplay, TextView instructionDisplay) {
+    /**
+     *
+     * @param memoryDisplay The memory display
+     * @param programCounterDisplay The program counter display
+     * @param instructionDisplay The instruction display
+     * @param registers The array of registers
+     */
+    public MachineInterface(TextView memoryDisplay, TextView programCounterDisplay, TextView instructionDisplay, TextView[] registers) {
         this.memoryDisplay = memoryDisplay;
         this.programCounterDisplay = programCounterDisplay;
         this.instructionDisplay = instructionDisplay;
+        this.registers = registers;
     }
 
     /**
@@ -39,5 +47,9 @@ public class MachineInterface {
      */
     public void updateInstructionDisplay(String instructions) {
         instructionDisplay.setText("Instructions: " + instructions);
+    }
+
+    public void updateIndividualRegister(int register, String registerValue) {
+        registers[register].setText(registerValue);
     }
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/MachineInterface.java
@@ -9,7 +9,7 @@ import android.widget.TextView;
  * Class used for communication from {@link io.github.danielt3131.mipsemu.machine.MipsMachine} to {@link io.github.danielt3131.mipsemu.ui.MachineActivity}
  */
 public class MachineInterface {
-    private TextView memoryDisplay, programCounterDisplay, instructionDisplay;
+    private TextView memoryDisplay, programCounterDisplay, instructionDisplay, cacheHitRateDisplay;
     private TextView[] registers;
 
     /**
@@ -18,12 +18,14 @@ public class MachineInterface {
      * @param programCounterDisplay The program counter display
      * @param instructionDisplay The instruction display
      * @param registers The array of registers
+     * @param cacheHitRateDisplay The cache hit rate display
      */
-    public MachineInterface(TextView memoryDisplay, TextView programCounterDisplay, TextView instructionDisplay, TextView[] registers) {
+    public MachineInterface(TextView memoryDisplay, TextView programCounterDisplay, TextView instructionDisplay, TextView[] registers, TextView cacheHitRateDisplay) {
         this.memoryDisplay = memoryDisplay;
         this.programCounterDisplay = programCounterDisplay;
         this.instructionDisplay = instructionDisplay;
         this.registers = registers;
+        this.cacheHitRateDisplay = cacheHitRateDisplay;
     }
 
     /**
@@ -73,5 +75,13 @@ public class MachineInterface {
                 Log.e("Update Register", e.getMessage());
             }
         }
+    }
+
+    /**
+     * Updates the cache hit display
+     * @param cacheHitRate The cache hit rate value
+     */
+    public void updateCacheHitDisplay(String cacheHitRate) {
+        cacheHitRateDisplay.setText("Cache Hits: " + cacheHitRate);
     }
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/Reference.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/Reference.java
@@ -4,6 +4,7 @@ public class Reference {
     public static final int HEX_MODE = 1;
     public static final int BINARY_MODE = 0;
     public static final int DECIMIAL_MODE = 2;
+    public static final int CREATE_OUTPUTSTREAM = 24;
 
     //  Registers
     public static final int REGISTER_ZERO = 0;

--- a/app/src/main/java/io/github/danielt3131/mipsemu/Reference.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/Reference.java
@@ -41,4 +41,9 @@ public class Reference {
     public static final int REGISTER_RA = 30;
     public static final int REGISTER_AT = 31;
 
+    // The name of each register index to the corresponding spot
+    public static final String[] registerNames = {"$zero", "$v0", "$v1", "$a0", "$a1", "$a2", "$t0", "$t1", "$t2",
+            "$t3", "$t4", "$t5", "$t6", "$t7", "$t8", "$t9", "$s0", "$s1", "$s2", "$s3", "$s4", "$s5", "$s6", "$s7",
+            "$k0", "$k1", "$gp", "$sp", "$fp", "$ra", "$at"};
+
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/Reference.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/Reference.java
@@ -42,7 +42,7 @@ public class Reference {
     public static final int REGISTER_AT = 31;
 
     // The name of each register index to the corresponding spot
-    public static final String[] registerNames = {"$zero", "$v0", "$v1", "$a0", "$a1", "$a2", "$t0", "$t1", "$t2",
+    public static final String[] registerNames = {"$zero", "$v0", "$v1", "$a0", "$a1", "$a2", "$a3", "$t0", "$t1", "$t2",
             "$t3", "$t4", "$t5", "$t6", "$t7", "$t8", "$t9", "$s0", "$s1", "$s2", "$s3", "$s4", "$s5", "$s6", "$s7",
             "$k0", "$k1", "$gp", "$sp", "$fp", "$ra", "$at"};
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -14,15 +14,11 @@
 
 package io.github.danielt3131.mipsemu.machine;
 
-import android.annotation.SuppressLint;
 import android.util.Log;
 
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +50,7 @@ public class MipsMachine {
 
     private MachineInterface machineInterface;
     private InputStream inputFileStream;
-    private int memoryFormat;
+    private int displayFormat;
     private Scanner fileScanner;
 
     /**
@@ -80,8 +76,12 @@ public class MipsMachine {
         }
     }
 
-    public void setMemoryFormat(int memoryFormat) {
-        this.memoryFormat = memoryFormat;
+    /**
+     * Sets the display format
+     * @param displayFormat The format specifier defined in {@link Reference}
+     */
+    public void setDisplayFormat(int displayFormat) {
+        this.displayFormat = displayFormat;
     }
 
     /**
@@ -495,11 +495,11 @@ public class MipsMachine {
      */
     public void sendMemory() {
         String memoryStr = "";
-        if (memoryFormat == Reference.HEX_MODE) {
+        if (displayFormat == Reference.HEX_MODE) {
             memoryStr = HexFormat.ofDelimiter(" ").formatHex(memory);
-        } else if (memoryFormat == Reference.BINARY_MODE) {
+        } else if (displayFormat == Reference.BINARY_MODE) {
             memoryStr = new BigInteger(memory).toString();
-        } else if (memoryFormat == Reference.DECIMIAL_MODE) {
+        } else if (displayFormat == Reference.DECIMIAL_MODE) {
             memoryStr = Arrays.toString(memory);
         }
         // Pass the memoryStr to update memory

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -18,8 +18,11 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -510,15 +513,14 @@ public class MipsMachine {
         machineInterface.updateInstructionDisplay(message);
     }
 
-    public void saveState() {
-        // Save the state.
-        State state = new State(register, pc, hi, lo, memory);
-        try {
-            state.toFile("state.mst");
-        } catch (IOException e) {
-            Log.e("State", e.getMessage());
-            throw new RuntimeException(e);
-        }
+    public void saveState(OutputStream outputStream) throws IOException {
+        // Write header
+//        PrintWriter printWriter = new PrintWriter(outputStream);
+//        printWriter.println("State");
+//        printWriter.close();
+        // Save the save
+        Log.d("saveState", "Starting to save the state");
+        StateManager.toFile(outputStream, register, pc, hi, lo, memory);
     }
 
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -18,6 +18,7 @@ import android.annotation.SuppressLint;
 import android.util.Log;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -510,6 +511,13 @@ public class MipsMachine {
 
     public void saveState() {
         // Save the state.
+        State state = new State(register, pc, hi, lo, memory);
+        try {
+            state.toFile("state.mst");
+        } catch (IOException e) {
+            Log.e("State", e.getMessage());
+            throw new RuntimeException(e);
+        }
     }
 
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -128,18 +128,19 @@ public class MipsMachine {
 
 
     private int mstep; //the micro step to run
+    private int code; //the instruction word to run
 
     /**
      * has the machine read from the program counter to fetch and execute the next instruction
      */
     private void nextStep() {
         //combines the 4 bytes into the full word
-        int code = combineBytes(memory[pc], memory[pc+1], memory[pc+2], memory[pc+3]);
+        code = combineBytes(memory[pc], memory[pc+1], memory[pc+2], memory[pc+3]);
         Log.d("Code", Integer.toBinaryString(code));
         boolean running = true;
         while(running) //keeps executing until it returns EOS when step is done
         {
-            running = nextMicroStep(code) != EOS;
+            running = nextMicroStep() != EOS;
         }
     }
 
@@ -154,14 +155,14 @@ public class MipsMachine {
      * Method to run next micro step as requested from the user or MipsMachine
      */
     public void runNextMicroStep() {
-        // Run the next microstep
+        nextMicroStep();
     }
 
     public void runContinuously() {
         // Run continuously
     }
 
-    private int nextMicroStep(int code)
+    private int nextMicroStep()
     {
         Log.d("mstep", "MSTEP: " + mstep);
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -550,10 +550,10 @@ public class MipsMachine {
     private void sendIndividualRegisterToDisplay(int registerIndex) {
         String registerString = "";
         if (displayFormat == Reference.HEX_MODE) {
-            registerString = Integer.toHexString(register[registerIndex]);
+            registerString = String.format("%8s", Integer.toHexString(register[registerIndex])).replace(" ", "0");  // 4 bytes -> 2 hex per byte  = 8
             //registerString = HexFormat.ofDelimiter("").formatHex(new byte[] {Byte.parseByte(String.valueOf(register[registerIndex]))}, registerIndex, registerIndex);
         } else if (displayFormat == Reference.BINARY_MODE) {
-            registerString = Integer.toBinaryString(register[registerIndex]);
+            registerString = String.format("%32s", Integer.toBinaryString(register[registerIndex])).replace(" ", "0");  // 4 bytes = 32 bits
         } else {
             registerString = String.valueOf(register[registerIndex]);
         }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -508,5 +508,9 @@ public class MipsMachine {
         machineInterface.updateInstructionDisplay(message);
     }
 
+    public void saveState() {
+        // Save the state.
+    }
+
 
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -501,12 +501,44 @@ public class MipsMachine {
         if (displayFormat == Reference.HEX_MODE) {
             memoryStr = HexFormat.ofDelimiter(" ").formatHex(memory);
         } else if (displayFormat == Reference.BINARY_MODE) {
-            memoryStr = new BigInteger(memory).toString();
+            memoryStr = binaryString();
         } else if (displayFormat == Reference.DECIMIAL_MODE) {
             memoryStr = Arrays.toString(memory);
         }
         // Pass the memoryStr to update memory
         machineInterface.updateMemoryDisplay(memoryStr);
+    }
+
+//    private String binaryString() {
+//        String memoryBinaryString = new BigInteger(memory).toString(2); // Memory as a binary formatted string
+//        // Add spaces between each byte
+//        String memoryBinaryStringSpaced = "";
+//        for (int i = 0; i < memoryBinaryString.length(); i++) {
+//
+//            if ((i % 8 == 0 || i == 7) && i != 0) {
+//                memoryBinaryStringSpaced = memoryBinaryStringSpaced + memoryBinaryString.charAt(i) + " ";
+//            } else {
+//                memoryBinaryStringSpaced = memoryBinaryStringSpaced + memoryBinaryString.charAt(i);
+//            }
+//        }
+//        return memoryBinaryStringSpaced;
+//
+//    }
+
+    /**
+     * Method to get a binary formatted string representing the memory
+     * @return The memory formatted as binary with a space between every byte
+     */
+    private String binaryString() {
+        byte[] indivByte = new byte[1];
+        String memoryString = "";
+        for (int i = 0; i < memory.length; i++) {
+            indivByte[0] = memory[i];
+            BigInteger getBinary = new BigInteger(indivByte);
+            // Add leading zeros and space -> 00101010 01110001 versus 1010101110001
+            memoryString = memoryString + String.format("%8s", getBinary.toString(2)).replace(" ", "0") + " ";
+        }
+       return memoryString;
     }
 
     public void sendToDisplay(String message)

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -164,11 +164,6 @@ public class MipsMachine {
 
     }
 
-    public void readState(State state) throws FileNotFoundException
-    {
-        //todo read from state file and update machine
-    }
-
 
     private int mstep; //the micro step to run
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -52,6 +52,7 @@ public class MipsMachine {
     private MachineInterface machineInterface;
     private InputStream inputFileStream;
     private int memoryFormat;
+    private Scanner fileScanner;
 
     /**
      * Constructor for the mips emulator
@@ -68,6 +69,12 @@ public class MipsMachine {
 
     public void setInputFileStream(InputStream inputFileStream) {
         this.inputFileStream = inputFileStream;
+        fileScanner = new Scanner(inputFileStream);
+        if (fileScanner.hasNext("State")) {
+            readState();
+        } else {
+            readFile();
+        }
     }
 
     public void setMemoryFormat(int memoryFormat) {
@@ -77,11 +84,10 @@ public class MipsMachine {
     /**
      * Reads in a file and puts the instructions into memory
      */
-    public void readFile() throws FileNotFoundException {
+    public void readFile() {
 
         int tp = 0; //tp for text pointer : where to place word in text block of memory
 
-        Scanner fileScanner = new Scanner(inputFileStream);
 
         while (fileScanner.hasNextLine()) {
             String line = fileScanner.nextLine();
@@ -132,7 +138,6 @@ public class MipsMachine {
      */
     public void readState()
     {
-        Scanner fileScanner = new Scanner(inputFileStream);
 
         //reads register
         for(int i = 0; i < 32; i++)

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -509,21 +509,6 @@ public class MipsMachine {
         machineInterface.updateMemoryDisplay(memoryStr);
     }
 
-//    private String binaryString() {
-//        String memoryBinaryString = new BigInteger(memory).toString(2); // Memory as a binary formatted string
-//        // Add spaces between each byte
-//        String memoryBinaryStringSpaced = "";
-//        for (int i = 0; i < memoryBinaryString.length(); i++) {
-//
-//            if ((i % 8 == 0 || i == 7) && i != 0) {
-//                memoryBinaryStringSpaced = memoryBinaryStringSpaced + memoryBinaryString.charAt(i) + " ";
-//            } else {
-//                memoryBinaryStringSpaced = memoryBinaryStringSpaced + memoryBinaryString.charAt(i);
-//            }
-//        }
-//        return memoryBinaryStringSpaced;
-//
-//    }
 
     /**
      * Method to get a binary formatted string representing the memory

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -126,6 +126,44 @@ public class MipsMachine {
         }
     }
 
+    /**
+     * reads from file a state and loads it into machine
+     */
+    public void readState()
+    {
+        Scanner fileScanner = new Scanner(inputFileStream);
+
+        //reads register
+        for(int i = 0; i < 32; i++)
+        {
+            register[i] = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+        }
+        //reads pc, hi, lo
+
+        pc = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+        hi = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+        lo = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+
+        //reads amount of memory
+        int memSize = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+        memory = new byte[memSize];
+
+        //sets the stack
+        int stackSize = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+        for(int i = memSize; i > memSize - stackSize; i--)
+        {
+            memory[i] = fileScanner.nextByte();
+        }
+
+        //sets the text
+        int textSize = combineBytes(fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte(), fileScanner.nextByte());
+        for(int i = 0; i < textSize; i++)
+        {
+            memory[i] = fileScanner.nextByte();
+        }
+
+    }
+
     public void readState(State state) throws FileNotFoundException
     {
         //todo read from state file and update machine

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -126,6 +126,11 @@ public class MipsMachine {
         }
     }
 
+    public void readState(State state) throws FileNotFoundException
+    {
+        //todo read from state file and update machine
+    }
+
 
     private int mstep; //the micro step to run
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/MipsMachine.java
@@ -257,8 +257,9 @@ public class MipsMachine {
                 }
                 else if(mstep == 4)
                 {
-                    sendToDisplay(String.format(Locale.US,"Placing %d in register %d", register[t] + register[s], d));
+                    sendToDisplay(String.format(Locale.US,"Placing %d in register %s", register[t] + register[s], Reference.registerNames[d]));
                     register[d] = register[s] + register[t];
+                    sendIndividualRegisterToDisplay(d);
                     mstep++;
                     return 0;
                 }
@@ -306,8 +307,9 @@ public class MipsMachine {
                 }
                 else if(mstep == 4)
                 {
-                    sendToDisplay(String.format(Locale.US,"Placing %d in register %d", register[t] - register[s], d));
+                    sendToDisplay(String.format(Locale.US,"Placing %d in register %s", register[t] - register[s], Reference.registerNames[d]));
                     register[d] = register[s] - register[t];
+                    sendIndividualRegisterToDisplay(d);
                     mstep++;
                     return 0;
                 }
@@ -363,8 +365,9 @@ public class MipsMachine {
                 }
                 else if(mstep == 4)
                 {
-                    sendToDisplay(String.format(Locale.US,"Placing %d in register %d", i + register[s], t));
+                    sendToDisplay(String.format(Locale.US,"Placing %d in register %s", i + register[s], Reference.registerNames[t]));
                     register[t] = register[s] + i;
+                    sendIndividualRegisterToDisplay(t);
                     mstep++;
                     return 0;
                 }
@@ -523,5 +526,30 @@ public class MipsMachine {
         StateManager.toFile(outputStream, register, pc, hi, lo, memory);
     }
 
+    /**
+     * Method to send a individual register to {@link MachineInterface} with the correct format
+     * @param registerIndex The register to select from in the register array
+     */
+    private void sendIndividualRegisterToDisplay(int registerIndex) {
+        String registerString = "";
+        if (displayFormat == Reference.HEX_MODE) {
+            registerString = Integer.toHexString(register[registerIndex]);
+            //registerString = HexFormat.ofDelimiter("").formatHex(new byte[] {Byte.parseByte(String.valueOf(register[registerIndex]))}, registerIndex, registerIndex);
+        } else if (displayFormat == Reference.BINARY_MODE) {
+            registerString = Integer.toBinaryString(register[registerIndex]);
+        } else {
+            registerString = String.valueOf(register[registerIndex]);
+        }
+        machineInterface.updateIndividualRegister(registerIndex, registerString);
+    }
+
+    /**
+     * Method to update all the register displays by calling sendIndividualRegisterToDisplay
+     */
+    public void sendAllRegistersToDisplay() {
+        for (int i = 0; i < register.length; i++) {
+            sendIndividualRegisterToDisplay(i);
+        }
+    }
 
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/State.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/State.java
@@ -52,7 +52,7 @@ public class State
 
      */
     public File toFile(String fileName) throws IOException {
-        File out = new File(fileName);
+        File out = new File("/storage/emulated/0/Documents" + fileName);
         FileOutputStream outputStream = null;
         try
         {

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/State.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/State.java
@@ -1,0 +1,182 @@
+package io.github.danielt3131.mipsemu.machine;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class State
+{
+
+    int[] register;
+    int pc, hi, lo;
+    byte[] memory;
+
+    ArrayList<Byte> byteArrayList = new ArrayList<>();
+
+    public State(int[] register, int pc, int hi, int lo, byte[] memory)
+    {
+        super();
+        this.register = register;
+        this.pc = pc;
+        this.hi = hi;
+        this.lo = lo;
+        this.memory = memory;
+    }
+
+    public State()
+    {
+        super();
+    }
+
+    /*
+    .mst file breakdown
+    first 128 bytes determine what is in register
+    pc (4 bytes)
+    hi (4 bytes)
+    lo (4 bytes)
+    amount of memory (4 bytes)
+    size of stack (4 bytes)
+    ...
+    the stack
+    ...
+    size of text (4 bytes)
+    ...
+    the text
+    ...
+
+
+     */
+    public File toFile(String fileName) throws IOException {
+        File out = new File(fileName);
+        FileOutputStream outputStream = null;
+        try
+        {
+            outputStream = new FileOutputStream(out);
+            createByteArray();
+            byte[] b = new byte[byteArrayList.size()];
+            for(int i = 0; i < b.length; i++)
+            {
+                b[i] = byteArrayList.get(i);
+            }
+            outputStream.write(b);
+            outputStream.flush();
+            outputStream.close();
+        } catch (FileNotFoundException e)
+        {
+            Log.e("FileNotFound",e.getMessage(),e);
+        }
+
+        return out;
+    }
+
+    private byte[] intToBytes(int i)
+    {
+        byte b1 = (byte)grabLeftBits(i , 8);
+        byte b2 = (byte)grabRightBits(grabLeftBits(i, 16),8);
+        byte b3 = (byte)grabRightBits(grabLeftBits(i, 24),8);
+        byte b4 = (byte)grabRightBits(i,8);
+
+        return new byte[]{b1, b2, b3, b4};
+    }
+
+    /**
+     * grabs right bits from an int
+     * @param data the integer to grab bits from
+     * @param n the amount of bits to grab
+     * @return the grabbed bits
+     */
+    private int grabRightBits(int data, int n)
+    {
+        int mask = (int)Math.pow(2,n) - 1;
+        return data & mask;
+    }
+
+    /**
+     * grabs left bits from an int
+     * @param data the integer to grab bits from
+     * @param n the amount of bits to grab
+     * @return the grabbed bits
+     */
+    private int grabLeftBits(int data, int n)
+    {
+        return data >>> 32-n;
+    }
+
+    private void addToByteArray(byte b)
+    {
+        byteArrayList.add(b);
+        Log.d("Writing File", String.format("added %d to file", b));
+    }
+
+    private void addToByteArray(byte[] b)
+    {
+        for(byte c : b)
+        {
+            addToByteArray(c);
+        }
+    }
+
+    private void createByteArray()
+    {
+        //Creating file
+
+        //Creating registers section
+        for(int i : register)
+        {
+            addToByteArray(intToBytes(i));
+        }
+
+        addToByteArray(intToBytes(pc));
+        addToByteArray(intToBytes(hi));
+        addToByteArray(intToBytes(lo));
+
+        //Amount of memory section
+
+        addToByteArray(intToBytes(memory.length));
+
+        //Calculating length of text and stack
+        int sizeOfText, sizeOfStack;
+
+        int mid = memory[memory.length/2];
+
+        //text
+
+        while(memory[mid] == 0)
+        {
+            mid--;
+        }
+        sizeOfText = mid + 1;
+
+        //Stack
+
+        mid = memory[memory.length / 2];
+
+        while(memory[mid] == 0)
+        {
+            mid++;
+        }
+        sizeOfStack = memory.length - mid + 1;
+
+        //Now we have sized partitions of the memory
+
+        //adding memory partitions to bytearray
+        addToByteArray(intToBytes(sizeOfText));
+        for(int i = 0; i < sizeOfText; i++)
+        {
+            addToByteArray(memory[i]);
+        }
+
+        addToByteArray(intToBytes(sizeOfStack));
+        for(int i = memory.length - 1; i > memory.length - sizeOfStack; i--)
+        {
+            addToByteArray(memory[i]);
+        }
+
+
+    }
+}

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/StateManager.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/StateManager.java
@@ -9,29 +9,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class State
+public class StateManager
 {
 
-    int[] register;
-    int pc, hi, lo;
-    byte[] memory;
-
-    ArrayList<Byte> byteArrayList = new ArrayList<>();
-
-    public State(int[] register, int pc, int hi, int lo, byte[] memory)
-    {
-        super();
-        this.register = register;
-        this.pc = pc;
-        this.hi = hi;
-        this.lo = lo;
-        this.memory = memory;
-    }
-
-    public State()
-    {
-        super();
-    }
+    private static ArrayList<Byte> byteArrayList = new ArrayList<>();
 
     /*
     .mst file breakdown
@@ -48,16 +29,14 @@ public class State
     ...
     the text
     ...
-
-
      */
-    public File toFile(String fileName) throws IOException {
+    public static File toFile(String fileName,int[] register, int pc, int hi, int lo, byte[] memory) throws IOException {
         File out = new File(fileName);
         FileOutputStream outputStream = null;
         try
         {
             outputStream = new FileOutputStream(out);
-            createByteArray();
+            createByteArray(register, pc, hi, lo,memory);
             byte[] b = new byte[byteArrayList.size()];
             for(int i = 0; i < b.length; i++)
             {
@@ -74,7 +53,7 @@ public class State
         return out;
     }
 
-    private byte[] intToBytes(int i)
+    private static byte[] intToBytes(int i)
     {
         byte b1 = (byte)grabLeftBits(i , 8);
         byte b2 = (byte)grabRightBits(grabLeftBits(i, 16),8);
@@ -90,7 +69,7 @@ public class State
      * @param n the amount of bits to grab
      * @return the grabbed bits
      */
-    private int grabRightBits(int data, int n)
+    private static int grabRightBits(int data, int n)
     {
         int mask = (int)Math.pow(2,n) - 1;
         return data & mask;
@@ -102,18 +81,18 @@ public class State
      * @param n the amount of bits to grab
      * @return the grabbed bits
      */
-    private int grabLeftBits(int data, int n)
+    private static int grabLeftBits(int data, int n)
     {
         return data >>> 32-n;
     }
 
-    private void addToByteArray(byte b)
+    private static void addToByteArray(byte b)
     {
         byteArrayList.add(b);
         Log.d("Writing File", String.format("added %d to file", b));
     }
 
-    private void addToByteArray(byte[] b)
+    private static void addToByteArray(byte[] b)
     {
         for(byte c : b)
         {
@@ -121,7 +100,7 @@ public class State
         }
     }
 
-    private void createByteArray()
+    private static void createByteArray(int[] register, int pc, int hi, int lo, byte[] memory)
     {
         //Creating file
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/machine/StateManager.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/machine/StateManager.java
@@ -7,6 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 
 public class StateManager
@@ -16,6 +17,7 @@ public class StateManager
 
     /*
     .mst file breakdown
+    State (Header)
     first 128 bytes determine what is in register
     pc (4 bytes)
     hi (4 bytes)
@@ -30,28 +32,20 @@ public class StateManager
     the text
     ...
      */
-    public static File toFile(String fileName,int[] register, int pc, int hi, int lo, byte[] memory) throws IOException {
-        File out = new File(fileName);
-
-        FileOutputStream outputStream = null;
-        try
-        {
-            outputStream = new FileOutputStream(out);
-            createByteArray(register, pc, hi, lo,memory);
+    public static void toFile(OutputStream outputStream, int[] register, int pc, int hi, int lo, byte[] memory) {
+        Log.d("StateManager", "Saving state");
+        try {
+            createByteArray(register, pc, hi, lo, memory);
             byte[] b = new byte[byteArrayList.size()];
-            for(int i = 0; i < b.length; i++)
-            {
+            for (int i = 0; i < b.length; i++) {
                 b[i] = byteArrayList.get(i);
             }
-            outputStream.write(b);
+            outputStream.write(b, 6, b.length);
             outputStream.flush();
             outputStream.close();
-        } catch (FileNotFoundException e)
-        {
-            Log.e("FileNotFound",e.getMessage(),e);
+        } catch (IOException e) {
+            Log.e("StateManager", e.getMessage());
         }
-
-        return out;
     }
 
     private static byte[] intToBytes(int i)

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -51,7 +51,7 @@ import io.github.danielt3131.mipsemu.machine.MipsMachine;
 public class MachineActivity extends AppCompatActivity implements ProgramCounterDialog.ProgramCounterDialogListener{
 
     Toolbar machineToolbar;
-    Button runOneTime, runMicroStep, runContinously, runFromState;
+    Button runOneTime, runMicroStep, runContinously;
     CheckBox decimalMode, binaryMode, hexMode;
     TextView memoryDisplay, programCounterDisplay, instructionDisplay;
     private final int FILE_OPEN_REQUEST = 4;
@@ -86,7 +86,6 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         runOneTime = findViewById(R.id.runStepButton);
         runMicroStep = findViewById(R.id.runMicroStepButton);
         runContinously = findViewById(R.id.runContinouslyButton);
-        runFromState = findViewById(R.id.runStateButton);
 
         // Set Checkboxes
         decimalMode = findViewById(R.id.decimialDisplayMode);
@@ -110,7 +109,6 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         runMicroStep.setOnClickListener(runMicroStepListener);
         runOneTime.setOnClickListener(runOneStepListener);
         runContinously.setOnClickListener(runContinuouslyListener);
-        runFromState.setOnClickListener(runFromStateListener);
     }
 
     // Create Mips Machine method
@@ -145,7 +143,8 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         }
         if (item.getItemId() == R.id.machineReset) {
             mipsMachine = null; // Deallocate the object
-            System.gc();    // Call the garbage collector to clean up mipsMachine
+            System.gc();// Call the garbage collector to clean up mipsMachine
+            gotInputStream = false;
             // Reset the machine by creating new object with the same reference name
             createMipsMachine();
             return true;
@@ -194,7 +193,6 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             super.onActivityResult(requestCode, resultCode, data);
         }
     }
-
     /**
      * Listeners for all checkboxes
      */
@@ -286,19 +284,6 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
                 mipsMachine.runContinuously();
             } else {
                 Toast.makeText(MachineActivity.this, "Need file", Toast.LENGTH_SHORT).show();
-            }
-        }
-    };
-
-
-    View.OnClickListener runFromStateListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View v) {
-            if (FileUtils.getFileName(MachineActivity.this, inputFileUri).contains(".mst")) {
-                mipsMachine.readState();
-                Log.d("State", "Reading in the state");
-            } else {
-                Toast.makeText(MachineActivity.this, "Wrong file", Toast.LENGTH_SHORT).show();
             }
         }
     };

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -208,9 +208,32 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
     private void resetMachine() {
         mipsMachine = null; // Deallocate the object
         System.gc();// Call the garbage collector to clean up mipsMachine
-        gotInputStream = false;
+        gotInputStream = false; // Require a new file selection
         // Reset the machine by creating new object with the same reference name
         createMipsMachine();
+
+        mipsMachine.setMemoryFormat(getDisplayMode());  // Provide the display mode to the machine
+
+        // Clear the displays
+        machineInterface.clearAll();
+
+        // Send the blank memory to be displayed
+        mipsMachine.sendMemory();
+
+    }
+
+    /**
+     * Method to get the current display mode hex, binary, or decimal
+     * @return The display mode
+     */
+    private int getDisplayMode() {
+        if (binaryMode.isChecked()) {
+            return Reference.BINARY_MODE;
+        } else if (hexMode.isChecked()) {
+            return Reference.HEX_MODE;
+        } else {
+            return Reference.DECIMIAL_MODE;
+        }
     }
 
     private void createOutputStream() {

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -49,7 +49,7 @@ import io.github.danielt3131.mipsemu.machine.MipsMachine;
 public class MachineActivity extends AppCompatActivity implements ProgramCounterDialog.ProgramCounterDialogListener{
 
     Toolbar machineToolbar;
-    Button runOneTime, runMicroStep, runContinously;
+    Button runOneTime, runMicroStep, runContinously, runFromState;
     CheckBox decimalMode, binaryMode, hexMode;
     TextView memoryDisplay, programCounterDisplay, instructionDisplay;
     private final int FILE_OPEN_REQUEST = 4;
@@ -84,6 +84,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         runOneTime = findViewById(R.id.runStepButton);
         runMicroStep = findViewById(R.id.runMicroStepButton);
         runContinously = findViewById(R.id.runContinouslyButton);
+        runFromState = findViewById(R.id.runStateButton);
 
         // Set Checkboxes
         decimalMode = findViewById(R.id.decimialDisplayMode);
@@ -107,6 +108,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         runMicroStep.setOnClickListener(runMicroStepListener);
         runOneTime.setOnClickListener(runOneStepListener);
         runContinously.setOnClickListener(runContinuouslyListener);
+        runFromState.setOnClickListener(runFromStateListener);
     }
 
     // Create Mips Machine method
@@ -261,6 +263,13 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             } else {
                 Toast.makeText(MachineActivity.this, "Need file", Toast.LENGTH_SHORT).show();
             }
+        }
+    };
+
+    View.OnClickListener runFromStateListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+
         }
     };
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -157,6 +157,9 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             createMipsMachine();
             return true;
         }
+        if (item.getItemId() == R.id.saveState) {
+            mipsMachine.saveState();
+        }
         return false;
     }
 

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -54,6 +54,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
     Button runOneTime, runMicroStep, runContinously;
     CheckBox decimalMode, binaryMode, hexMode;
     TextView memoryDisplay, programCounterDisplay, instructionDisplay;
+    TextView[] registerDispalys;
     private final int FILE_OPEN_REQUEST = 4;
     Uri inputFileUri, outputFileUri;
     MipsMachine mipsMachine;
@@ -82,6 +83,9 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         programCounterDisplay = findViewById(R.id.programCounterDisplay);
         instructionDisplay = findViewById(R.id.instructionDisplay);
 
+        // Inflate the registers
+        inflateRegisters();
+
         // Set buttons
         runOneTime = findViewById(R.id.runStepButton);
         runMicroStep = findViewById(R.id.runMicroStepButton);
@@ -96,7 +100,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         setSupportActionBar(machineToolbar);
 
         // Create Machine interface
-        machineInterface = new MachineInterface(memoryDisplay, programCounterDisplay, instructionDisplay);
+        machineInterface = new MachineInterface(memoryDisplay, programCounterDisplay, instructionDisplay, registerDispalys);
 
         // Create the machine
         createMipsMachine();
@@ -115,6 +119,53 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
 
     private void createMipsMachine() {
         mipsMachine = new MipsMachine(2000, machineInterface);
+    }
+
+    /**
+     * Creates register text view array and set each element to its text view
+     */
+    private void inflateRegisters() {
+        registerDispalys = new TextView[32];    // The number of registers
+        registerDispalys[Reference.REGISTER_ZERO] = findViewById(R.id.register_ZERO);
+
+        registerDispalys[Reference.REGISTER_V0] = findViewById(R.id.register_V0);
+        registerDispalys[Reference.REGISTER_V1] = findViewById(R.id.register_V1);
+
+        registerDispalys[Reference.REGISTER_T0] = findViewById(R.id.register_T0);
+        registerDispalys[Reference.REGISTER_T1] = findViewById(R.id.register_T1);
+        registerDispalys[Reference.REGISTER_T2] = findViewById(R.id.register_T2);
+        registerDispalys[Reference.REGISTER_T3] = findViewById(R.id.register_T3);
+        registerDispalys[Reference.REGISTER_T4] = findViewById(R.id.register_T4);
+        registerDispalys[Reference.REGISTER_T5] = findViewById(R.id.register_T5);
+        registerDispalys[Reference.REGISTER_T6] = findViewById(R.id.register_T6);
+        registerDispalys[Reference.REGISTER_T7] = findViewById(R.id.register_T7);
+        registerDispalys[Reference.REGISTER_T8] = findViewById(R.id.register_T8);
+        registerDispalys[Reference.REGISTER_T9] = findViewById(R.id.register_T9);
+
+        registerDispalys[Reference.REGISTER_A0] = findViewById(R.id.register_A0);
+        registerDispalys[Reference.REGISTER_A1] = findViewById(R.id.register_A1);
+        registerDispalys[Reference.REGISTER_A2] = findViewById(R.id.register_A2);
+        registerDispalys[Reference.REGISTER_A3] = findViewById(R.id.register_A3);
+
+        registerDispalys[Reference.REGISTER_K0] = findViewById(R.id.register_K0);
+        registerDispalys[Reference.REGISTER_K1] = findViewById(R.id.register_K1);
+
+        registerDispalys[Reference.REGISTER_S0] = findViewById(R.id.register_S0);
+        registerDispalys[Reference.REGISTER_S1] = findViewById(R.id.register_S1);
+        registerDispalys[Reference.REGISTER_S2] = findViewById(R.id.register_S2);
+        registerDispalys[Reference.REGISTER_S3] = findViewById(R.id.register_S3);
+        registerDispalys[Reference.REGISTER_S4] = findViewById(R.id.register_S4);
+        registerDispalys[Reference.REGISTER_S5] = findViewById(R.id.register_S5);
+        registerDispalys[Reference.REGISTER_S6] = findViewById(R.id.register_S6);
+        registerDispalys[Reference.REGISTER_S7] = findViewById(R.id.register_S7);
+
+        registerDispalys[Reference.REGISTER_FP] = findViewById(R.id.register_FP);
+        registerDispalys[Reference.REGISTER_SP] = findViewById(R.id.register_SP);
+        registerDispalys[Reference.REGISTER_GP] = findViewById(R.id.register_GP);
+        registerDispalys[Reference.REGISTER_RA] = findViewById(R.id.register_RA);
+        registerDispalys[Reference.REGISTER_AT] = findViewById(R.id.register_AT);
+
+
     }
 
     // Create the menu options in the toolbar

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -41,6 +41,7 @@ import androidx.fragment.app.DialogFragment;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
+import io.github.danielt3131.mipsemu.FileUtils;
 import io.github.danielt3131.mipsemu.MachineInterface;
 import io.github.danielt3131.mipsemu.R;
 import io.github.danielt3131.mipsemu.Reference;
@@ -269,7 +270,12 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
     View.OnClickListener runFromStateListener = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-
+            if (FileUtils.getFileName(MachineActivity.this, fileUri).contains(".mst")) {
+                mipsMachine.readState();
+                Log.d("State", "Reading in the state");
+            } else {
+                Toast.makeText(MachineActivity.this, "Wrong file", Toast.LENGTH_SHORT).show();
+            }
         }
     };
 }

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -13,11 +13,14 @@
  */
 package io.github.danielt3131.mipsemu.ui;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
+import android.provider.Settings;
 import android.text.method.ScrollingMovementMethod;
 import android.util.Log;
 import android.view.Menu;
@@ -75,6 +78,11 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
 
         // Set toolbar
         machineToolbar = findViewById(R.id.materialToolbar);
+        if (!Environment.isExternalStorageManager()) {
+            Toast.makeText(this, "Need all file access", Toast.LENGTH_SHORT).show();
+            Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+            startActivity(intent);
+        }
 
         // Set textViews
         memoryDisplay = findViewById(R.id.memoryView);
@@ -266,6 +274,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             }
         }
     };
+
 
     View.OnClickListener runFromStateListener = new View.OnClickListener() {
         @Override

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -108,7 +108,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         // Init the displays
         machineInterface.clearAll();    // Clear the display to display proper register names
         hexMode.setChecked(true);   // Set the default memory display mode to be hex
-        mipsMachine.setMemoryFormat(Reference.HEX_MODE);
+        mipsMachine.setDisplayFormat(Reference.HEX_MODE);
         mipsMachine.sendMemory();   // Show blank memory to display
 
         // Set buttons and checkboxes to their listeners
@@ -218,7 +218,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         // Reset the machine by creating new object with the same reference name
         createMipsMachine();
 
-        mipsMachine.setMemoryFormat(getDisplayMode());  // Provide the display mode to the machine
+        mipsMachine.setDisplayFormat(getDisplayMode());  // Provide the display mode to the machine
 
         // Clear the displays
         machineInterface.clearAll();
@@ -291,7 +291,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             binaryMode.setChecked(false);
 
             // Tell MipsMachine the memory display option
-            mipsMachine.setMemoryFormat(Reference.HEX_MODE);
+            mipsMachine.setDisplayFormat(Reference.HEX_MODE);
             mipsMachine.sendMemory();
         }
     };
@@ -304,7 +304,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             binaryMode.setChecked(false);
 
             // Tell MipsMachine the memory display option
-            mipsMachine.setMemoryFormat(Reference.DECIMIAL_MODE);
+            mipsMachine.setDisplayFormat(Reference.DECIMIAL_MODE);
             mipsMachine.sendMemory();
         }
     };
@@ -317,7 +317,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             hexMode.setChecked(false);
 
             // Tell MipsMachine the memory display option
-            mipsMachine.setMemoryFormat(Reference.BINARY_MODE);
+            mipsMachine.setDisplayFormat(Reference.BINARY_MODE);
             mipsMachine.sendMemory();
         }
     };

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -105,6 +105,12 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         // Create the machine
         createMipsMachine();
 
+        // Init the displays
+        machineInterface.clearAll();    // Clear the display to display proper register names
+        hexMode.setChecked(true);   // Set the default memory display mode to be hex
+        mipsMachine.setMemoryFormat(Reference.HEX_MODE);
+        mipsMachine.sendMemory();   // Show blank memory to display
+
         // Set buttons and checkboxes to their listeners
         decimalMode.setOnClickListener(decimalModeListener);
         hexMode.setOnClickListener(hexModeListener);

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -193,17 +193,24 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             return true;
         }
         if (item.getItemId() == R.id.machineReset) {
-            mipsMachine = null; // Deallocate the object
-            System.gc();// Call the garbage collector to clean up mipsMachine
-            gotInputStream = false;
-            // Reset the machine by creating new object with the same reference name
-            createMipsMachine();
+            resetMachine();
             return true;
         }
         if (item.getItemId() == R.id.saveState) {
             createOutputStream();
         }
         return false;
+    }
+
+    /**
+     * Method to reset the machine
+     */
+    private void resetMachine() {
+        mipsMachine = null; // Deallocate the object
+        System.gc();// Call the garbage collector to clean up mipsMachine
+        gotInputStream = false;
+        // Reset the machine by creating new object with the same reference name
+        createMipsMachine();
     }
 
     private void createOutputStream() {

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import io.github.danielt3131.mipsemu.FileUtils;
 import io.github.danielt3131.mipsemu.MachineInterface;
 import io.github.danielt3131.mipsemu.R;
 import io.github.danielt3131.mipsemu.Reference;
@@ -53,7 +52,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
     Toolbar machineToolbar;
     Button runOneTime, runMicroStep, runContinously;
     CheckBox decimalMode, binaryMode, hexMode;
-    TextView memoryDisplay, programCounterDisplay, instructionDisplay;
+    TextView memoryDisplay, programCounterDisplay, instructionDisplay, cacheHitRateDisplay;
     TextView[] registerDispalys;
     private final int FILE_OPEN_REQUEST = 4;
     Uri inputFileUri, outputFileUri;
@@ -82,6 +81,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         memoryDisplay = findViewById(R.id.memoryView);
         programCounterDisplay = findViewById(R.id.programCounterDisplay);
         instructionDisplay = findViewById(R.id.instructionDisplay);
+        cacheHitRateDisplay = findViewById(R.id.cacheHitRate);
 
         // Inflate the registers
         inflateRegisters();
@@ -100,7 +100,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         setSupportActionBar(machineToolbar);
 
         // Create Machine interface
-        machineInterface = new MachineInterface(memoryDisplay, programCounterDisplay, instructionDisplay, registerDispalys);
+        machineInterface = new MachineInterface(memoryDisplay, programCounterDisplay, instructionDisplay, registerDispalys, cacheHitRateDisplay);
 
         // Create the machine
         createMipsMachine();

--- a/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
+++ b/app/src/main/java/io/github/danielt3131/mipsemu/ui/MachineActivity.java
@@ -110,6 +110,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
         hexMode.setChecked(true);   // Set the default memory display mode to be hex
         mipsMachine.setDisplayFormat(Reference.HEX_MODE);
         mipsMachine.sendMemory();   // Show blank memory to display
+        mipsMachine.sendAllRegistersToDisplay();
 
         // Set buttons and checkboxes to their listeners
         decimalMode.setOnClickListener(decimalModeListener);
@@ -293,6 +294,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             // Tell MipsMachine the memory display option
             mipsMachine.setDisplayFormat(Reference.HEX_MODE);
             mipsMachine.sendMemory();
+            mipsMachine.sendAllRegistersToDisplay();
         }
     };
 
@@ -306,6 +308,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             // Tell MipsMachine the memory display option
             mipsMachine.setDisplayFormat(Reference.DECIMIAL_MODE);
             mipsMachine.sendMemory();
+            mipsMachine.sendAllRegistersToDisplay();
         }
     };
 
@@ -319,6 +322,7 @@ public class MachineActivity extends AppCompatActivity implements ProgramCounter
             // Tell MipsMachine the memory display option
             mipsMachine.setDisplayFormat(Reference.BINARY_MODE);
             mipsMachine.sendMemory();
+            mipsMachine.sendAllRegistersToDisplay();
         }
     };
 

--- a/app/src/main/res/layout-sw600dp/activity_machine.xml
+++ b/app/src/main/res/layout-sw600dp/activity_machine.xml
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.MachineActivity">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/materialToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="736dp"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?attr/actionBarTheme"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        app:menu="@menu/toolbar" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="1dp"
+        android:layout_marginTop="1dp"
+        android:layout_marginEnd="1dp"
+        android:layout_marginBottom="1dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/materialToolbar">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="254dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/memoryView"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="20dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/decimialDisplayMode"
+                android:layout_width="142dp"
+                android:layout_height="wrap_content"
+                android:text="Decimial" />
+
+            <CheckBox
+                android:id="@+id/hexDisplayMode"
+                android:layout_width="137dp"
+                android:layout_height="wrap_content"
+                android:text="Hex" />
+
+            <CheckBox
+                android:id="@+id/binaryDisplayMode"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:text="Binary" />
+
+        </LinearLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="25dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Space
+                android:layout_width="10dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <Button
+                android:id="@+id/runStepButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Step Once" />
+
+            <Space
+                android:layout_width="20dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <Button
+                android:id="@+id/runMicroStepButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Step One Microstep" />
+
+            <Space
+                android:layout_width="20dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <Button
+                android:id="@+id/runContinouslyButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Run" />
+
+            <Space
+                android:layout_width="10dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="25dp" />
+
+        <TextView
+            android:id="@+id/instructionDisplay"
+            android:layout_width="match_parent"
+            android:layout_height="54dp"
+            android:text="Instructions" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="25dp" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" >
+
+                <LinearLayout
+                    android:id="@+id/pcFpSp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/programCounterDisplay"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Program Counter:" />
+
+                    <TextView
+                        android:id="@+id/register_SP"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="$sp" />
+
+                    <TextView
+                        android:id="@+id/register_FP"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="$fp" />
+
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_ZERO"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Zero" />
+
+                    <TextView
+                        android:id="@+id/register_V0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="V0" />
+
+                    <TextView
+                        android:id="@+id/register_V1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="V1" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_A0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A0" />
+
+                    <TextView
+                        android:id="@+id/register_A1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A1" />
+
+                    <TextView
+                        android:id="@+id/register_A2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A2" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_A3"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A3" />
+
+                    <TextView
+                        android:id="@+id/register_T0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T0" />
+
+                    <TextView
+                        android:id="@+id/register_T1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T1" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_T2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T2" />
+
+                    <TextView
+                        android:id="@+id/register_T3"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T3" />
+
+                    <TextView
+                        android:id="@+id/register_T4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T4" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_T5"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T5" />
+
+                    <TextView
+                        android:id="@+id/register_T6"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T6" />
+
+                    <TextView
+                        android:id="@+id/register_T7"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T7" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_T8"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T8" />
+
+                    <TextView
+                        android:id="@+id/register_T9"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T9" />
+
+                    <TextView
+                        android:id="@+id/register_S0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S0" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_S1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S1" />
+
+                    <TextView
+                        android:id="@+id/register_S2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S2" />
+
+                    <TextView
+                        android:id="@+id/register_S3"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S3" />
+
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_S4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S4" />
+
+                    <TextView
+                        android:id="@+id/register_S5"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S5" />
+
+                    <TextView
+                        android:id="@+id/register_S6"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S6" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_S7"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S7" />
+
+                    <TextView
+                        android:id="@+id/register_K0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="K0" />
+
+                    <TextView
+                        android:id="@+id/register_K1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="K1" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_GP"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="GP" />
+
+                    <TextView
+                        android:id="@+id/register_RA"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="RA" />
+
+                    <TextView
+                        android:id="@+id/register_AT"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="AT" />
+
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="25dp" />
+
+                <TextView
+                    android:id="@+id/cacheHitRate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Cache Hit Rate" />
+            </LinearLayout>
+        </ScrollView>
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -146,339 +146,367 @@
             android:layout_width="match_parent"
             android:layout_height="25dp" />
 
-        <LinearLayout
-            android:id="@+id/pcFpSp"
+        <ScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_height="match_parent">
 
-            <TextView
-                android:id="@+id/programCounterDisplay"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Program Counter:" />
+                android:orientation="vertical" >
 
-            <TextView
-                android:id="@+id/register_SP"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="$sp" />
+                <LinearLayout
+                    android:id="@+id/pcFpSp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_FP"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="$fp" />
+                    <TextView
+                        android:id="@+id/programCounterDisplay"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Program Counter:" />
 
-        </LinearLayout>
+                    <TextView
+                        android:id="@+id/register_SP"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="$sp" />
 
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
+                    <TextView
+                        android:id="@+id/register_FP"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="$fp" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_ZERO"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Zero" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <TextView
-                android:id="@+id/register_V0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="V0" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_V1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="V1" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/register_ZERO"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Zero" />
 
-            <TextView
-                android:id="@+id/register_A0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="A0" />
+                    <TextView
+                        android:id="@+id/register_V0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="V0" />
 
-            <TextView
-                android:id="@+id/register_A1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="A1" />
+                    <TextView
+                        android:id="@+id/register_V1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="V1" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_A2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="A2" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <TextView
-                android:id="@+id/register_A3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="A3" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_T0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T0" />
+                    <TextView
+                        android:id="@+id/register_A0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A0" />
 
-            <TextView
-                android:id="@+id/register_T1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T1" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/register_A1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A1" />
 
-            <TextView
-                android:id="@+id/register_T2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T2" />
+                    <TextView
+                        android:id="@+id/register_A2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A2" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_T3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T3" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <TextView
-                android:id="@+id/register_T4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T4" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_T5"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T5" />
+                    <TextView
+                        android:id="@+id/register_A3"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="A3" />
 
-            <TextView
-                android:id="@+id/register_T6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T6" />
+                    <TextView
+                        android:id="@+id/register_T0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T0" />
 
-            <TextView
-                android:id="@+id/register_T7"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T7" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/register_T1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T1" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_T8"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T8" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <TextView
-                android:id="@+id/register_T9"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="T9" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_S0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S0" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/register_T2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T2" />
 
-            <TextView
-                android:id="@+id/register_S1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S1" />
+                    <TextView
+                        android:id="@+id/register_T3"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T3" />
 
-            <TextView
-                android:id="@+id/register_S2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S2" />
+                    <TextView
+                        android:id="@+id/register_T4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T4" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_S3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S3" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_S4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S4" />
+                    <TextView
+                        android:id="@+id/register_T5"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T5" />
 
-            <TextView
-                android:id="@+id/register_S5"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S5" />
+                    <TextView
+                        android:id="@+id/register_T6"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T6" />
 
-            <TextView
-                android:id="@+id/register_S6"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S6" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/register_T7"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T7" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_S7"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="S7" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <TextView
-                android:id="@+id/register_K0"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="K0" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/register_K1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="K1" />
-        </LinearLayout>
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="10dp" />
+                    <TextView
+                        android:id="@+id/register_T8"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T8" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+                    <TextView
+                        android:id="@+id/register_T9"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="T9" />
 
-            <TextView
-                android:id="@+id/register_GP"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="GP" />
+                    <TextView
+                        android:id="@+id/register_S0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S0" />
+                </LinearLayout>
 
-            <TextView
-                android:id="@+id/register_RA"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="RA" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
 
-            <TextView
-                android:id="@+id/register_AT"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="AT" />
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
 
-        </LinearLayout>
+                    <TextView
+                        android:id="@+id/register_S1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S1" />
 
-        <Space
-            android:layout_width="match_parent"
-            android:layout_height="25dp" />
+                    <TextView
+                        android:id="@+id/register_S2"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S2" />
 
-        <TextView
-            android:id="@+id/cacheHitRate"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Cache Hit Rate" />
+                    <TextView
+                        android:id="@+id/register_S3"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S3" />
+
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_S4"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S4" />
+
+                    <TextView
+                        android:id="@+id/register_S5"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S5" />
+
+                    <TextView
+                        android:id="@+id/register_S6"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S6" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_S7"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="S7" />
+
+                    <TextView
+                        android:id="@+id/register_K0"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="K0" />
+
+                    <TextView
+                        android:id="@+id/register_K1"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="K1" />
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/register_GP"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="GP" />
+
+                    <TextView
+                        android:id="@+id/register_RA"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="RA" />
+
+                    <TextView
+                        android:id="@+id/register_AT"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="AT" />
+
+                </LinearLayout>
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="25dp" />
+
+                <TextView
+                    android:id="@+id/cacheHitRate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Cache Hit Rate" />
+            </LinearLayout>
+        </ScrollView>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -130,6 +130,13 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1" />
 
+            <Button
+                android:id="@+id/runStateButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Run from state" />
+
         </LinearLayout>
 
         <Space

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -130,13 +130,6 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1" />
 
-            <Button
-                android:id="@+id/runStateButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Run from state" />
-
         </LinearLayout>
 
         <Space
@@ -146,7 +139,7 @@
         <TextView
             android:id="@+id/instructionDisplay"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="54dp"
             android:text="Instructions" />
 
         <Space

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -147,7 +147,7 @@
             android:layout_height="25dp" />
 
         <LinearLayout
-            android:id="@+id/Registers1_5"
+            android:id="@+id/pcFpSp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
@@ -160,25 +160,312 @@
                 android:text="Program Counter:" />
 
             <TextView
-                android:id="@+id/registerT0_Display"
+                android:id="@+id/register_SP"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="$sp" />
+
+            <TextView
+                android:id="@+id/register_FP"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="$fp" />
+
+        </LinearLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_ZERO"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Zero" />
+
+            <TextView
+                android:id="@+id/register_V0"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="V0" />
+
+            <TextView
+                android:id="@+id/register_V1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="V1" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_A0"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="A0" />
+
+            <TextView
+                android:id="@+id/register_A1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="A1" />
+
+            <TextView
+                android:id="@+id/register_A2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="A2" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_A3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="A3" />
+
+            <TextView
+                android:id="@+id/register_T0"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="T0" />
 
             <TextView
-                android:id="@+id/registerT1_Display"
+                android:id="@+id/register_T1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="T1" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/registerT2_Display"
+                android:id="@+id/register_T2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="T2" />
+
+            <TextView
+                android:id="@+id/register_T3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T3" />
+
+            <TextView
+                android:id="@+id/register_T4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T4" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_T5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T5" />
+
+            <TextView
+                android:id="@+id/register_T6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T6" />
+
+            <TextView
+                android:id="@+id/register_T7"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T7" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_T8"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T8" />
+
+            <TextView
+                android:id="@+id/register_T9"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="T9" />
+
+            <TextView
+                android:id="@+id/register_S0"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S0" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_S1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S1" />
+
+            <TextView
+                android:id="@+id/register_S2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S2" />
+
+            <TextView
+                android:id="@+id/register_S3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S3" />
+
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_S4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S4" />
+
+            <TextView
+                android:id="@+id/register_S5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S5" />
+
+            <TextView
+                android:id="@+id/register_S6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S6" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_S7"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="S7" />
+
+            <TextView
+                android:id="@+id/register_K0"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="K0" />
+
+            <TextView
+                android:id="@+id/register_K1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="K1" />
+        </LinearLayout>
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="10dp" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/register_GP"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="GP" />
+
+            <TextView
+                android:id="@+id/register_RA"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="RA" />
+
+            <TextView
+                android:id="@+id/register_AT"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="AT" />
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -155,350 +155,236 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical" >
 
-                <LinearLayout
-                    android:id="@+id/pcFpSp"
+                <TextView
+                    android:id="@+id/programCounterDisplay"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="Program Counter:" />
 
-                    <TextView
-                        android:id="@+id/programCounterDisplay"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Program Counter:" />
-
-                    <TextView
-                        android:id="@+id/register_SP"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="$sp" />
-
-                    <TextView
-                        android:id="@+id/register_FP"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="$fp" />
-
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_SP"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="$sp" />
 
-                    <TextView
-                        android:id="@+id/register_ZERO"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Zero" />
-
-                    <TextView
-                        android:id="@+id/register_V0"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="V0" />
-
-                    <TextView
-                        android:id="@+id/register_V1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="V1" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_FP"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="$fp" />
 
-                    <TextView
-                        android:id="@+id/register_A0"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="A0" />
-
-                    <TextView
-                        android:id="@+id/register_A1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="A1" />
-
-                    <TextView
-                        android:id="@+id/register_A2"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="A2" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_ZERO"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="Zero" />
 
-                    <TextView
-                        android:id="@+id/register_A3"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="A3" />
-
-                    <TextView
-                        android:id="@+id/register_T0"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T0" />
-
-                    <TextView
-                        android:id="@+id/register_T1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T1" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_V0"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="V0" />
 
-                    <TextView
-                        android:id="@+id/register_T2"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T2" />
-
-                    <TextView
-                        android:id="@+id/register_T3"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T3" />
-
-                    <TextView
-                        android:id="@+id/register_T4"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T4" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_V1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="V1" />
 
-                    <TextView
-                        android:id="@+id/register_T5"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T5" />
-
-                    <TextView
-                        android:id="@+id/register_T6"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T6" />
-
-                    <TextView
-                        android:id="@+id/register_T7"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T7" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_A0"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="A0" />
 
-                    <TextView
-                        android:id="@+id/register_T8"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T8" />
-
-                    <TextView
-                        android:id="@+id/register_T9"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="T9" />
-
-                    <TextView
-                        android:id="@+id/register_S0"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S0" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_A1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="A1" />
 
-                    <TextView
-                        android:id="@+id/register_S1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S1" />
-
-                    <TextView
-                        android:id="@+id/register_S2"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S2" />
-
-                    <TextView
-                        android:id="@+id/register_S3"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S3" />
-
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_A2"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="A2" />
 
-                    <TextView
-                        android:id="@+id/register_S4"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S4" />
-
-                    <TextView
-                        android:id="@+id/register_S5"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S5" />
-
-                    <TextView
-                        android:id="@+id/register_S6"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S6" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_A3"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="A3" />
 
-                    <TextView
-                        android:id="@+id/register_S7"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="S7" />
-
-                    <TextView
-                        android:id="@+id/register_K0"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="K0" />
-
-                    <TextView
-                        android:id="@+id/register_K1"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="K1" />
-                </LinearLayout>
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="10dp" />
-
-                <LinearLayout
+                <TextView
+                    android:id="@+id/register_T0"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="T0" />
 
-                    <TextView
-                        android:id="@+id/register_GP"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="GP" />
-
-                    <TextView
-                        android:id="@+id/register_RA"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="RA" />
-
-                    <TextView
-                        android:id="@+id/register_AT"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="AT" />
-
-                </LinearLayout>
-
-                <Space
+                <TextView
+                    android:id="@+id/register_T1"
                     android:layout_width="match_parent"
-                    android:layout_height="25dp" />
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T1" />
+
+                <TextView
+                    android:id="@+id/register_T2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T2" />
+
+                <TextView
+                    android:id="@+id/register_T3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T3" />
+
+                <TextView
+                    android:id="@+id/register_T4"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T4" />
+
+                <TextView
+                    android:id="@+id/register_T5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T5" />
+
+                <TextView
+                    android:id="@+id/register_T6"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T6" />
+
+                <TextView
+                    android:id="@+id/register_T7"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T7" />
+
+                <TextView
+                    android:id="@+id/register_T8"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T8" />
+
+                <TextView
+                    android:id="@+id/register_T9"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="T9" />
+
+                <TextView
+                    android:id="@+id/register_S0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S0" />
+
+                <TextView
+                    android:id="@+id/register_S1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S1" />
+
+                <TextView
+                    android:id="@+id/register_S2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S2" />
+
+                <TextView
+                    android:id="@+id/register_S3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S3" />
+
+                <TextView
+                    android:id="@+id/register_S4"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S4" />
+
+                <TextView
+                    android:id="@+id/register_S5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S5" />
+
+                <TextView
+                    android:id="@+id/register_S6"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S6" />
+
+                <TextView
+                    android:id="@+id/register_S7"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="S7" />
+
+                <TextView
+                    android:id="@+id/register_K0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="K0" />
+
+                <TextView
+                    android:id="@+id/register_K1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="K1" />
+
+                <TextView
+                    android:id="@+id/register_GP"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="GP" />
+
+                <TextView
+                    android:id="@+id/register_RA"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="RA" />
+
+                <TextView
+                    android:id="@+id/register_AT"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="AT" />
 
                 <TextView
                     android:id="@+id/cacheHitRate"

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -441,6 +441,7 @@
         <Space
             android:layout_width="match_parent"
             android:layout_height="10dp" />
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -471,8 +472,7 @@
 
         <Space
             android:layout_width="match_parent"
-            android:layout_height="25dp"
-            android:layout_weight="1" />
+            android:layout_height="25dp" />
 
         <TextView
             android:id="@+id/cacheHitRate"

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -466,7 +466,19 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="AT" />
+
         </LinearLayout>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="25dp"
+            android:layout_weight="1" />
+
+        <TextView
+            android:id="@+id/cacheHitRate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Cache Hit Rate" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_machine.xml
+++ b/app/src/main/res/layout/activity_machine.xml
@@ -162,12 +162,22 @@
                     android:layout_weight="1"
                     android:text="Program Counter:" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
+
                 <TextView
                     android:id="@+id/register_SP"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="$sp" />
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_FP"
@@ -176,12 +186,22 @@
                     android:layout_weight="1"
                     android:text="$fp" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
+
                 <TextView
                     android:id="@+id/register_ZERO"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="Zero" />
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_V0"
@@ -190,12 +210,22 @@
                     android:layout_weight="1"
                     android:text="V0" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
+
                 <TextView
                     android:id="@+id/register_V1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="V1" />
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_A0"
@@ -204,12 +234,22 @@
                     android:layout_weight="1"
                     android:text="A0" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
+
                 <TextView
                     android:id="@+id/register_A1"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="A1" />
+
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_A2"
@@ -218,6 +258,11 @@
                     android:layout_weight="1"
                     android:text="A2" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
+
                 <TextView
                     android:id="@+id/register_A3"
                     android:layout_width="match_parent"
@@ -225,12 +270,21 @@
                     android:layout_weight="1"
                     android:text="A3" />
 
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
+
                 <TextView
                     android:id="@+id/register_T0"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T0" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T1"
@@ -238,6 +292,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T1" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T2"
@@ -245,6 +303,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T2" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T3"
@@ -252,6 +314,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T3" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T4"
@@ -259,6 +325,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T4" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T5"
@@ -266,6 +336,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T5" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T6"
@@ -273,6 +347,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T6" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T7"
@@ -280,6 +358,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T7" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T8"
@@ -287,6 +369,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T8" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_T9"
@@ -294,6 +380,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="T9" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S0"
@@ -301,6 +391,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S0" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S1"
@@ -308,6 +402,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S1" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S2"
@@ -315,6 +413,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S2" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S3"
@@ -322,6 +424,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S3" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S4"
@@ -329,6 +435,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S4" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S5"
@@ -336,6 +446,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S5" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S6"
@@ -343,6 +457,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S6" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_S7"
@@ -350,6 +468,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="S7" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_K0"
@@ -357,6 +479,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="K0" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_K1"
@@ -364,6 +490,10 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="K1" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/register_GP"
@@ -371,20 +501,30 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="GP" />
-
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
                 <TextView
                     android:id="@+id/register_RA"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="RA" />
-
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
                 <TextView
                     android:id="@+id/register_AT"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:text="AT" />
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="5dp"
+                    android:layout_weight="1" />
 
                 <TextView
                     android:id="@+id/cacheHitRate"

--- a/app/src/main/res/menu/toolbar.xml
+++ b/app/src/main/res/menu/toolbar.xml
@@ -11,4 +11,7 @@
     <item
         android:id="@+id/machineReset"
         android:title="Reset machine" />
+    <item
+        android:id="@+id/saveState"
+        android:title="Save state" />
 </menu>


### PR DESCRIPTION
Added display for all the registers and MipsMachine now shows the registers to the user with the correct formatting option of hex, binary, or decimal.
  
Added display for the cache hit.

Pulled in changes from origin/state-mangement and origin/sub
State management is able to currently write the machine state without a header but cannot load in the state due to the need for a header to distingush from an instruction file.

Have the instruction view display which register a value is going into.  
Refactored MachineActivity
Displaying the binary mode for the memory now works correctly.

Created a new UI for phones that displays each register in its own line, along with the Tablet UI that displays 3 registers per line.
